### PR TITLE
[RPC] Create Billplz\PaymentCompletion class to handle callback and redirect urls when creating bills.

### DIFF
--- a/examples/v3/creating-bill.php
+++ b/examples/v3/creating-bill.php
@@ -13,7 +13,7 @@ $response = $billplz->bill()->create(
     null,
     'Mior Muhammad Zaki',
     300,
-    'https://localhost/webhook/billplz',
+    new Billplz\PaymentCompletion('https://localhost/webhook/billplz'),
     'My first bill'
 );
 

--- a/src/Base/Bill.php
+++ b/src/Base/Bill.php
@@ -7,6 +7,7 @@ use InvalidArgumentException;
 use Laravie\Codex\Contracts\Response;
 use Billplz\Contracts\Bill as Contract;
 use Laravie\Codex\Concerns\Request\Multipart;
+use Billplz\PaymentCompletion as PaymentCompletionUrl;
 use Billplz\Contracts\PaymentCompletion as PaymentCompletionContract;
 
 abstract class Bill extends Request implements Contract
@@ -18,6 +19,7 @@ abstract class Bill extends Request implements Contract
      * Create a new bill.
      *
      * @param  \Money\Money|\Duit\MYR|int  $amount
+     * @param  \Billplz\Contracts\PaymentCompletion|string $paymentCompletion
      *
      * @throws \InvalidArgumentException
      *
@@ -29,7 +31,7 @@ abstract class Bill extends Request implements Contract
         ?string $mobile,
         string $name,
         $amount,
-        PaymentCompletionContract $paymentCompletion,
+        $paymentCompletion,
         string $description,
         array $optional = []
     ): Response {
@@ -42,6 +44,10 @@ abstract class Bill extends Request implements Contract
         );
 
         $body['collection_id'] = $collectionId;
+
+        $paymentCompletion = $paymentCompletion instanceof PaymentCompletionContract
+            ? $paymentCompletion
+            : new PaymentCompletionUrl($paymentCompletion);
 
         $body = \array_merge($body, $paymentCompletion->toArray());
 

--- a/src/Base/Bill.php
+++ b/src/Base/Bill.php
@@ -2,11 +2,12 @@
 
 namespace Billplz\Base;
 
+use Billplz\Contracts\Bill as Contract;
+use Billplz\Contracts\PaymentCompletion as PaymentCompletionContract;
 use Billplz\Request;
 use InvalidArgumentException;
-use Laravie\Codex\Contracts\Response;
-use Billplz\Contracts\Bill as Contract;
 use Laravie\Codex\Concerns\Request\Multipart;
+use Laravie\Codex\Contracts\Response;
 
 abstract class Bill extends Request implements Contract
 {
@@ -17,7 +18,6 @@ abstract class Bill extends Request implements Contract
      * Create a new bill.
      *
      * @param  \Money\Money|\Duit\MYR|int  $amount
-     * @param  array|string  $callbackUrl
      *
      * @throws \InvalidArgumentException
      *
@@ -29,7 +29,7 @@ abstract class Bill extends Request implements Contract
         ?string $mobile,
         string $name,
         $amount,
-        $callbackUrl,
+        PaymentCompletionContract $paymentCompletion,
         string $description,
         array $optional = []
     ): Response {
@@ -43,7 +43,7 @@ abstract class Bill extends Request implements Contract
 
         $body['collection_id'] = $collectionId;
 
-        $body = $this->parseRedirectAndCallbackUrlFromRequest($body, $callbackUrl);
+        $body = \array_merge($body, $paymentCompletion->toArray());
 
         return $this->stream('POST', 'bills', [], $body);
     }

--- a/src/Base/Bill.php
+++ b/src/Base/Bill.php
@@ -2,12 +2,12 @@
 
 namespace Billplz\Base;
 
-use Billplz\Contracts\Bill as Contract;
-use Billplz\Contracts\PaymentCompletion as PaymentCompletionContract;
 use Billplz\Request;
 use InvalidArgumentException;
-use Laravie\Codex\Concerns\Request\Multipart;
 use Laravie\Codex\Contracts\Response;
+use Billplz\Contracts\Bill as Contract;
+use Laravie\Codex\Concerns\Request\Multipart;
+use Billplz\Contracts\PaymentCompletion as PaymentCompletionContract;
 
 abstract class Bill extends Request implements Contract
 {

--- a/src/Contracts/Bill.php
+++ b/src/Contracts/Bill.php
@@ -11,6 +11,7 @@ interface Bill extends Request
      * Create a new bill.
      *
      * @param  \Money\Money|\Duit\MYR|int  $amount
+     * @param  \Billplz\Contracts\PaymentCompletion|string $paymentCompletion
      *
      * @throws \InvalidArgumentException
      */
@@ -20,7 +21,7 @@ interface Bill extends Request
         ?string $mobile,
         string $name,
         $amount,
-        PaymentCompletion $paymentCompletion,
+        $paymentCompletion,
         string $description,
         array $optional = []
     ): Response;

--- a/src/Contracts/Bill.php
+++ b/src/Contracts/Bill.php
@@ -11,7 +11,6 @@ interface Bill extends Request
      * Create a new bill.
      *
      * @param  \Money\Money|\Duit\MYR|int  $amount
-     * @param  array|string  $callbackUrl
      *
      * @throws \InvalidArgumentException
      */
@@ -21,7 +20,7 @@ interface Bill extends Request
         ?string $mobile,
         string $name,
         $amount,
-        $callbackUrl,
+        PaymentCompletion $paymentCompletion,
         string $description,
         array $optional = []
     ): Response;

--- a/src/Contracts/PaymentCompletion.php
+++ b/src/Contracts/PaymentCompletion.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Billplz\Contracts;
+
+interface PaymentCompletion
+{
+    /**
+     * Get Webhook URL.
+     */
+    public function webhookUrl(): string;
+
+    /**
+     * Get Redirect URL.
+     */
+    public function redirectUrl(): ?string;
+
+    /**
+     * Convert to array.
+     */
+    public function toArray(): array;
+}

--- a/src/PaymentCompletion.php
+++ b/src/PaymentCompletion.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Billplz;
+
+class PaymentCompletion implements Contracts\PaymentCompletion
+{
+    /**
+     * Webhook URL.
+     *
+     * @var string
+     */
+    protected $webhookUrl;
+
+    /**
+     * Redirect URL.
+     *
+     * @var string|null
+     */
+    protected $redirectUrl;
+
+    /**
+     * Construct Payment Completion.
+     */
+    public function __construct(string $callbackUrl, ?string $redirectUrl = null)
+    {
+        $this->webhookUrl = $callbackUrl;
+        $this->redirectUrl = $redirectUrl;
+    }
+
+    /**
+     * Get Webhook URL.
+     */
+    public function webhookUrl(): string
+    {
+        return $this->webhookUrl;
+    }
+
+    /**
+     * Get Redirect URL.
+     */
+    public function redirectUrl(): ?string
+    {
+        return $this->redirectUrl;
+    }
+
+    /**
+     * Convert to array.
+     */
+    public function toArray(): array
+    {
+        return [
+            'callback_url' => $this->webhookUrl,
+            'redirect_url' => $this->redirectUrl,
+        ];
+    }
+}

--- a/src/Request.php
+++ b/src/Request.php
@@ -44,21 +44,4 @@ abstract class Request extends \Laravie\Codex\Request implements Filterable
     {
         return new Sanitizer();
     }
-
-    /**
-     * Parse callback URL from request.
-     *
-     * @param  array|string  $url
-     */
-    final protected function parseRedirectAndCallbackUrlFromRequest(array $body, $url): array
-    {
-        if (\is_string($url)) {
-            $body['callback_url'] = $url;
-        } elseif (\is_array($url)) {
-            $body['callback_url'] = $url['callback_url'] ?? null;
-            $body['redirect_url'] = $url['redirect_url'] ?? null;
-        }
-
-        return $body;
-    }
 }

--- a/tests/Base/BillTestCase.php
+++ b/tests/Base/BillTestCase.php
@@ -2,10 +2,11 @@
 
 namespace Billplz\Tests\Base;
 
-use Duit\MYR;
+use Billplz\PaymentCompletion;
 use Billplz\Tests\TestCase;
-use Laravie\Codex\Response;
+use Duit\MYR;
 use Laravie\Codex\Exceptions\HttpException;
+use Laravie\Codex\Response;
 
 abstract class BillTestCase extends TestCase
 {
@@ -44,7 +45,7 @@ abstract class BillTestCase extends TestCase
                             $payload['mobile'],
                             $payload['name'],
                             MYR::given($payload['amount']),
-                            $payload['callback_url'],
+                            new PaymentCompletion($payload['callback_url']),
                             $payload['description']
                         );
 
@@ -83,10 +84,9 @@ abstract class BillTestCase extends TestCase
                             $payload['mobile'],
                             $payload['name'],
                             MYR::given($payload['amount']),
-                            [
-                                'callback_url' => $payload['callback_url'],
-                                'redirect_url' => $payload['redirect_url'],
-                            ],
+                            new PaymentCompletion(
+                                $payload['callback_url'], $payload['redirect_url'],
+                            ),
                             $payload['description']
                         );
 
@@ -122,7 +122,7 @@ abstract class BillTestCase extends TestCase
                             $payload['mobile'],
                             $payload['name'],
                             MYR::given($payload['amount']),
-                            $payload['callback_url'],
+                            new PaymentCompletion($payload['callback_url']),
                             $payload['description']
                         );
     }

--- a/tests/Base/BillTestCase.php
+++ b/tests/Base/BillTestCase.php
@@ -2,11 +2,11 @@
 
 namespace Billplz\Tests\Base;
 
-use Billplz\PaymentCompletion;
-use Billplz\Tests\TestCase;
 use Duit\MYR;
-use Laravie\Codex\Exceptions\HttpException;
+use Billplz\Tests\TestCase;
 use Laravie\Codex\Response;
+use Billplz\PaymentCompletion;
+use Laravie\Codex\Exceptions\HttpException;
 
 abstract class BillTestCase extends TestCase
 {

--- a/tests/Base/BillTestCase.php
+++ b/tests/Base/BillTestCase.php
@@ -85,7 +85,7 @@ abstract class BillTestCase extends TestCase
                             $payload['name'],
                             MYR::given($payload['amount']),
                             new PaymentCompletion(
-                                $payload['callback_url'], $payload['redirect_url'],
+                                $payload['callback_url'], $payload['redirect_url']
                             ),
                             $payload['description']
                         );

--- a/tests/PaymentCompletionTest.php
+++ b/tests/PaymentCompletionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Billplz\Tests;
+
+use Billplz\PaymentCompletion;
+use PHPUnit\Framework\TestCase;
+
+class PaymentCompletionTest extends TestCase
+{
+    /** @test */
+    public function it_can_generate_without_redirect_url()
+    {
+        $payment = new PaymentCompletion('http://example.com/webhook/');
+
+        $this->assertSame('http://example.com/webhook/', $payment->webhookUrl());
+        $this->assertNull($payment->redirectUrl());
+        $this->assertSame([
+            'callback_url' => 'http://example.com/webhook/',
+            'redirect_url' => null,
+        ], $payment->toArray());
+    }
+
+    /** @test */
+    public function it_can_generate_with_redirect_url()
+    {
+        $payment = new PaymentCompletion('http://example.com/webhook/', 'http://example.com/redirect/');
+
+        $this->assertSame('http://example.com/webhook/', $payment->webhookUrl());
+        $this->assertSame('http://example.com/redirect/', $payment->redirectUrl());
+        $this->assertSame([
+            'callback_url' => 'http://example.com/webhook/',
+            'redirect_url' => 'http://example.com/redirect/',
+        ], $payment->toArray());
+    }
+}


### PR DESCRIPTION
### Current Behaviour.

```php
use Duit\MYR;

$response = $bill->create(
    'inbmmepb',
    'api@billplz.com',
    null,
    'Michael API V3',
    MYR::given(200),
    ['callback_url' => 'http://example.com/webhook/', 'redirect_url' => null],
    'Maecenas eu placerat ante.'
);
```

### New Behaviour

```php
use Billplz\PaymentCompletion;
use Duit\MYR;

$response = $bill->create(
    'inbmmepb',
    'api@billplz.com',
    null,
    'Michael API V3',
    MYR::given(200),
    new PaymentCompletion('http://example.com/webhook/', null),
    'Maecenas eu placerat ante.'
);
```

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>