### PR TITLE
Include redirect_url in PaymentCompletionUrl instance

### DIFF
--- a/src/Base/Bill.php
+++ b/src/Base/Bill.php
@@ -47,7 +47,7 @@ abstract class Bill extends Request implements Contract
 
         $paymentCompletion = $paymentCompletion instanceof PaymentCompletionContract
             ? $paymentCompletion
-            : new PaymentCompletionUrl($paymentCompletion);
+            : new PaymentCompletionUrl($paymentCompletion, $optional['redirect_url']?? null);
 
         $body = \array_merge($body, $paymentCompletion->toArray());
 


### PR DESCRIPTION

Make setting redirect_url works for both of this.

1. Pass `PaymentCompletion` instance following #43 
```
use Billplz\PaymentCompletion;
use Duit\MYR;

$response = $bill->create(
    'inbmmepb',
    'api@billplz.com',
    null,
    'Michael API V3',
    MYR::given(200),
    new PaymentCompletion('http://example.com/webhook/', 'http://example.com/webhook/'),
    'Maecenas eu placerat ante.'
);
```

2. Passing optional parameter just like described in docs

```
$response = $bill->create(
    'inbmmepb',
    'api@billplz.com',
    null,
    'Michael API V3',
    \Duit\MYR::given(200),
     'http://example.com/webhook/', ,
    'Maecenas eu placerat ante.',
    ['redirect_url' => 'http://example.com/redirect/']
);

```

