### PR TITLE
Update PaymentMethod.php

### DIFF
--- a/src/Base/Collection/PaymentMethod.php
+++ b/src/Base/Collection/PaymentMethod.php
@@ -28,7 +28,7 @@ class PaymentMethod extends Request implements Contract
         foreach ($codes as $code) {
             array_push($payments['payment_methods'], compact('code'));
         }
-        
+
         return $this->send('PUT', "collections/{$collectionId}/payment_methods", [
             'Content-Type' => 'application/json',
         ], $payments);

--- a/src/Base/Collection/PaymentMethod.php
+++ b/src/Base/Collection/PaymentMethod.php
@@ -23,12 +23,14 @@ class PaymentMethod extends Request implements Contract
      */
     public function update(string $collectionId, array $codes = []): Response
     {
-        $payments = [];
+        $payments['payment_methods'] = [];
 
         foreach ($codes as $code) {
-            array_push($payments, compact('code'));
+            array_push($payments['payment_methods'], compact('code'));
         }
-
-        return $this->send('PUT', "collections/{$collectionId}/payment_methods", [], $payments);
+        
+        return $this->send('PUT', "collections/{$collectionId}/payment_methods", [
+            'Content-Type' => 'application/json',
+        ], $payments);
     }
 }

--- a/src/Base/PaymentCompletion.php
+++ b/src/Base/PaymentCompletion.php
@@ -72,7 +72,7 @@ trait PaymentCompletion
         }
 
         if (! $signature->verify($bill, $bill['x_signature'])) {
-            throw new FailedSignatureVerification();
+            throw new FailedSignatureVerification;
         }
 
         return true;

--- a/src/Request.php
+++ b/src/Request.php
@@ -43,6 +43,6 @@ abstract class Request extends \Laravie\Codex\Request implements Filterable
      */
     protected function sanitizeWith(): Sanitizer
     {
-        return new Sanitizer();
+        return new Sanitizer;
     }
 }

--- a/tests/Casts/DateTimeTest.php
+++ b/tests/Casts/DateTimeTest.php
@@ -10,7 +10,7 @@ class DateTimeTest extends TestCase
     /** @test */
     public function it_can_cast_datetime_to_string()
     {
-        $cast = new DateTime();
+        $cast = new DateTime;
 
         $this->assertSame('2018-01-01', $cast->from(new \DateTime('2018-01-01 11:00:01')));
     }
@@ -18,7 +18,7 @@ class DateTimeTest extends TestCase
     /** @test */
     public function it_wouldnt_cast_datetime_if_not_validated()
     {
-        $cast = new DateTime();
+        $cast = new DateTime;
 
         $this->assertSame('foo', $cast->from('foo'));
     }
@@ -26,7 +26,7 @@ class DateTimeTest extends TestCase
     /** @test */
     public function it_can_cast_string_to_datetime()
     {
-        $cast = new DateTime();
+        $cast = new DateTime;
 
         $this->assertInstanceOf('DateTimeInterface', $cast->to('2018-01-01'));
     }
@@ -34,7 +34,7 @@ class DateTimeTest extends TestCase
     /** @test */
     public function it_can_cast_none_string_to_datetime()
     {
-        $cast = new DateTime();
+        $cast = new DateTime;
 
         $this->assertNull($cast->to(null));
     }

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -10,6 +10,6 @@ class SanitizerTest extends PHPUnit
     /** @test */
     public function it_has_proper_signature()
     {
-        $this->assertInstanceOf('Laravie\Codex\Filter\Sanitizer', new Sanitizer());
+        $this->assertInstanceOf('Laravie\Codex\Filter\Sanitizer', new Sanitizer);
     }
 }


### PR DESCRIPTION
Fix wrong parameter of payment_methods. Fix according to billplz api reference

error occured before fix
"{"error":{"type":"UNPROCESSABLE_ENTITY","message":["Payment channels can't be blank"]}}"